### PR TITLE
Make noteId arg mandatory

### DIFF
--- a/app/src/main/java/com/jshvarts/notesnavigation/presentation/notedetail/NoteDetailFragment.kt
+++ b/app/src/main/java/com/jshvarts/notesnavigation/presentation/notedetail/NoteDetailFragment.kt
@@ -35,12 +35,12 @@ class NoteDetailFragment : Fragment() {
 
         val args = fromBundle(arguments)
         editNoteButton.setOnClickListener {
-            val navDirections = actionNoteDetailToEditNote().setNoteId(args.noteId)
+            val navDirections = actionNoteDetailToEditNote(args.noteId)
             it.findNavController().navigate(navDirections)
         }
 
         deleteNoteButton.setOnClickListener {
-            val navDirections = actionNoteDetailToDeleteNote().setNoteId(args.noteId)
+            val navDirections = actionNoteDetailToDeleteNote(args.noteId)
             it.findNavController().navigate(navDirections)
         }
     }

--- a/app/src/main/java/com/jshvarts/notesnavigation/presentation/notelist/NoteListFragment.kt
+++ b/app/src/main/java/com/jshvarts/notesnavigation/presentation/notelist/NoteListFragment.kt
@@ -62,7 +62,7 @@ class NoteListFragment : Fragment() {
 
     private fun onNoteClicked(note: Note) {
         view?.let {
-            val navDirections = actionNotesToNoteDetail().setNoteId(note.id)
+            val navDirections = actionNotesToNoteDetail(note.id)
             it.findNavController().navigate(navDirections)
         }
     }

--- a/app/src/main/res/navigation/mobile_navigation.xml
+++ b/app/src/main/res/navigation/mobile_navigation.xml
@@ -29,7 +29,6 @@
 
         <argument
             android:name="noteId"
-            android:defaultValue="0"
             app:argType="integer" />
 
         <action
@@ -56,7 +55,6 @@
 
         <argument
             android:name="noteId"
-            android:defaultValue="0"
             app:argType="integer" />
     </fragment>
 
@@ -68,7 +66,6 @@
 
         <argument
             android:name="noteId"
-            android:defaultValue="0"
             app:argType="integer" />
     </fragment>
 


### PR DESCRIPTION
Having `android:defaultValue="0"` in the navigation graph xml makes the arg optional. Remove the default attribute to make the arg mandatory.