### PR TITLE
Replace navigateUp with popBackStack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Android Navigation Architecture Component Demo
 
-This repo contains a comprehensive sample of using the [Navigation Architecture Component](https://developer.android.com/topic/libraries/architecture/navigation/) by way of a simple Notes app--no domain knowledge needed to understand the purpose of this app.
+My article covering this repo: [Navigation Architecture Component for the Rest of Us](https://proandroiddev.com/navigation-architecture-component-for-the-rest-of-us-faafa890e5)
+
+This project contains a comprehensive sample of using the [Navigation Architecture Component](https://developer.android.com/topic/libraries/architecture/navigation/) by way of a simple Notes app--no domain knowledge needed to understand the purpose of this app.
 
 ## Functionality included
 1) List notes

--- a/app/src/main/java/com/jshvarts/notesnavigation/presentation/addnote/AddNoteFragment.kt
+++ b/app/src/main/java/com/jshvarts/notesnavigation/presentation/addnote/AddNoteFragment.kt
@@ -44,7 +44,7 @@ class AddNoteFragment : Fragment() {
         when (status) {
             true -> {
                 view?.let { v ->
-                    v.findNavController().navigateUp()
+                    v.findNavController().popBackStack()
                 }
             }
             false -> addNoteText.error = getString(R.string.error_validating_note)

--- a/app/src/main/java/com/jshvarts/notesnavigation/presentation/deletenote/DeleteNoteFragment.kt
+++ b/app/src/main/java/com/jshvarts/notesnavigation/presentation/deletenote/DeleteNoteFragment.kt
@@ -37,7 +37,7 @@ class DeleteNoteFragment : Fragment() {
         viewModel.initNote(args.noteId)
 
         cancelDeleteButton.setOnClickListener { v ->
-            v.findNavController().navigateUp()
+            v.findNavController().popBackStack()
         }
 
         confirmDeleteButton.setOnClickListener {

--- a/app/src/main/java/com/jshvarts/notesnavigation/presentation/editnote/EditNoteFragment.kt
+++ b/app/src/main/java/com/jshvarts/notesnavigation/presentation/editnote/EditNoteFragment.kt
@@ -48,7 +48,7 @@ class EditNoteFragment : Fragment() {
         when (editStatus) {
             true -> {
                 view?.let { v ->
-                    v.findNavController().navigateUp()
+                    v.findNavController().popBackStack()
                 }
             }
             false -> editNoteText.error = getString(R.string.error_validating_note)


### PR DESCRIPTION
Since all navigation happens within a single app task, `popBackStack()` is more appropriate than `navigateUp()` when returning to previous screen.